### PR TITLE
added jdk installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,4 @@ To configure CI for your project, run the ci-cd sub-generator (`jhipster ci-cd`)
 [Jest]: https://facebook.github.io/jest/
 [Leaflet]: https://leafletjs.com/
 [DefinitelyTyped]: https://definitelytyped.org/
+[jdk-17.0.7]: https://adoptium.net/temurin/releases/?version=17


### PR DESCRIPTION
small update to README.md providing installation instructions for the Java JDK (openjdk 17.07)